### PR TITLE
Update swift 6.0 migration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,3 +26,12 @@ let package = Package(
     ),
   ]
 )
+
+#if compiler(>=6)
+  for target in package.targets where target.type != .test {
+    target.swiftSettings = target.swiftSettings ?? []
+    target.swiftSettings?.append(contentsOf: [
+      .enableExperimentalFeature("StrictConcurrency")
+    ])
+  }
+#endif

--- a/Sources/Toast/Internals/ToastManager.swift
+++ b/Sources/Toast/Internals/ToastManager.swift
@@ -47,11 +47,11 @@ internal final class ToastManager: ObservableObject {
       } catch {}
     }
   }
-
+  
   @discardableResult
   internal func append<V>(
     message: String,
-    task: () async throws -> V,
+    task: AsyncOperation<V>,
     onSuccess: (V) -> ToastValue,
     onFailure: (any Error) -> ToastValue
   ) async throws -> V {
@@ -72,3 +72,9 @@ internal final class ToastManager: ObservableObject {
 }
 
 internal let removalAnimationDuration: Double = 0.3
+
+#if compiler(>=6)
+public typealias AsyncOperation<V> = () async throws -> sending V
+#else
+public typealias AsyncOperation<V> = () async throws -> V
+#endif

--- a/Sources/Toast/PresentToastAction.swift
+++ b/Sources/Toast/PresentToastAction.swift
@@ -7,6 +7,9 @@ extension EnvironmentValues {
   }
 }
 
+#if compiler(>=6)
+@MainActor
+#endif
 public struct PresentToastAction {
   internal weak var _manager: ToastManager?
   private var manager: ToastManager {
@@ -20,10 +23,10 @@ public struct PresentToastAction {
   public func callAsFunction(_ toast: ToastValue) {
     manager.append(toast)
   }
-
+  
   public func callAsFunction<V>(
     message: String,
-    task: () async throws -> V,
+    task: AsyncOperation<V>,
     onSuccess: (V) -> ToastValue,
     onFailure: (any Error) -> ToastValue
   ) async throws -> V {


### PR DESCRIPTION
### ‼️ error: Non-sendable type 'V' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary; this is an error in the Swift 6 language mode
swift 6에서 발생하는 제네릭과 관련해서 발생하는 문제를 sending 주석을 통해 해결했습니다.


### ‼️ error: Call to main actor-isolated initializer 'init()' in a synchronous nonisolated context
1. 패키지 파일 수정
패키지 파일에서 StrictConcurrency 옵션을 켜주면 문제가 사라집니다.

2. PresentToastKey을 수정하기
``` swift
@MainActor
private enum PresentToastKey: @preconcurrency EnvironmentKey {
  static let defaultValue: PresentToastAction = .init()
}
```

제 생각에는 패키지 파일에서 옵션을 켜주는게 더 깔끔해보여서 1번을 반영한 상태입니다.